### PR TITLE
ひとつ進む／ひとつ戻る機能を […] に追加する

### DIFF
--- a/functions/src/__snapshots__/component.test.tsx.snap
+++ b/functions/src/__snapshots__/component.test.tsx.snap
@@ -561,7 +561,7 @@ Array [
       "type": "overflow",
     },
     "text": Object {
-      "text": "&gt; 👑 <@user-b|>→ <@user-c|>→<@user-a|>
+      "text": "&gt; 👑 <@user-c|>→ <@user-a|>→<@user-b|>
 &gt; ",
       "type": "mrkdwn",
       "verbatim": true,

--- a/functions/src/__snapshots__/component.test.tsx.snap
+++ b/functions/src/__snapshots__/component.test.tsx.snap
@@ -19,6 +19,30 @@ message line 2
         Object {
           "text": Object {
             "emoji": true,
+            "text": "➡️ ひとつ進む",
+            "type": "plain_text",
+          },
+          "value": "rotate:rotation-id",
+        },
+        Object {
+          "text": Object {
+            "emoji": true,
+            "text": "⬅️ ひとつ戻る",
+            "type": "plain_text",
+          },
+          "value": "unrotate:rotation-id",
+        },
+        Object {
+          "text": Object {
+            "emoji": true,
+            "text": "───────────────────",
+            "type": "plain_text",
+          },
+          "value": "noop:rotation-id",
+        },
+        Object {
+          "text": Object {
+            "emoji": true,
             "text": "削除",
             "type": "plain_text",
           },
@@ -525,6 +549,30 @@ Array [
     "accessory": Object {
       "action_id": "overflow_menu",
       "options": Array [
+        Object {
+          "text": Object {
+            "emoji": true,
+            "text": "➡️ ひとつ進む",
+            "type": "plain_text",
+          },
+          "value": "rotate:rotation-id",
+        },
+        Object {
+          "text": Object {
+            "emoji": true,
+            "text": "⬅️ ひとつ戻る",
+            "type": "plain_text",
+          },
+          "value": "unrotate:rotation-id",
+        },
+        Object {
+          "text": Object {
+            "emoji": true,
+            "text": "───────────────────",
+            "type": "plain_text",
+          },
+          "value": "noop:rotation-id",
+        },
         Object {
           "text": Object {
             "emoji": true,

--- a/functions/src/__snapshots__/component.test.tsx.snap
+++ b/functions/src/__snapshots__/component.test.tsx.snap
@@ -552,30 +552,6 @@ Array [
         Object {
           "text": Object {
             "emoji": true,
-            "text": "➡️ ひとつ進む",
-            "type": "plain_text",
-          },
-          "value": "rotate:rotation-id",
-        },
-        Object {
-          "text": Object {
-            "emoji": true,
-            "text": "⬅️ ひとつ戻る",
-            "type": "plain_text",
-          },
-          "value": "unrotate:rotation-id",
-        },
-        Object {
-          "text": Object {
-            "emoji": true,
-            "text": "───────────────────",
-            "type": "plain_text",
-          },
-          "value": "noop:rotation-id",
-        },
-        Object {
-          "text": Object {
-            "emoji": true,
             "text": "削除",
             "type": "plain_text",
           },

--- a/functions/src/__snapshots__/component.test.tsx.snap
+++ b/functions/src/__snapshots__/component.test.tsx.snap
@@ -19,7 +19,7 @@ message line 2
         Object {
           "text": Object {
             "emoji": true,
-            "text": "➡️ ひとつ進む",
+            "text": "ひとつ進む",
             "type": "plain_text",
           },
           "value": "rotate:rotation-id",
@@ -27,7 +27,7 @@ message line 2
         Object {
           "text": Object {
             "emoji": true,
-            "text": "⬅️ ひとつ戻る",
+            "text": "ひとつ戻る",
             "type": "plain_text",
           },
           "value": "unrotate:rotation-id",

--- a/functions/src/__snapshots__/index.test.ts.snap
+++ b/functions/src/__snapshots__/index.test.ts.snap
@@ -54,7 +54,7 @@ Array [
             "type": "overflow",
           },
           "text": Object {
-            "text": "👑 <@user-a|>→ <@user-b|>→<@user-c|>",
+            "text": "👑 <@user-b|>→ <@user-c|>→<@user-a|>",
             "type": "mrkdwn",
             "verbatim": true,
           },
@@ -118,7 +118,7 @@ Array [
             "type": "overflow",
           },
           "text": Object {
-            "text": "👑 <@user-q|>→<@user-p|>",
+            "text": "👑 <@user-p|>→<@user-q|>",
             "type": "mrkdwn",
             "verbatim": true,
           },

--- a/functions/src/__snapshots__/index.test.ts.snap
+++ b/functions/src/__snapshots__/index.test.ts.snap
@@ -21,6 +21,30 @@ Array [
               Object {
                 "text": Object {
                   "emoji": true,
+                  "text": "➡️ ひとつ進む",
+                  "type": "plain_text",
+                },
+                "value": "rotate:rotation-1",
+              },
+              Object {
+                "text": Object {
+                  "emoji": true,
+                  "text": "⬅️ ひとつ戻る",
+                  "type": "plain_text",
+                },
+                "value": "unrotate:rotation-1",
+              },
+              Object {
+                "text": Object {
+                  "emoji": true,
+                  "text": "───────────────────",
+                  "type": "plain_text",
+                },
+                "value": "noop:rotation-1",
+              },
+              Object {
+                "text": Object {
+                  "emoji": true,
                   "text": "削除",
                   "type": "plain_text",
                 },
@@ -58,6 +82,30 @@ Array [
           "accessory": Object {
             "action_id": "overflow_menu",
             "options": Array [
+              Object {
+                "text": Object {
+                  "emoji": true,
+                  "text": "➡️ ひとつ進む",
+                  "type": "plain_text",
+                },
+                "value": "rotate:rotation-2",
+              },
+              Object {
+                "text": Object {
+                  "emoji": true,
+                  "text": "⬅️ ひとつ戻る",
+                  "type": "plain_text",
+                },
+                "value": "unrotate:rotation-2",
+              },
+              Object {
+                "text": Object {
+                  "emoji": true,
+                  "text": "───────────────────",
+                  "type": "plain_text",
+                },
+                "value": "noop:rotation-2",
+              },
               Object {
                 "text": Object {
                   "emoji": true,
@@ -612,6 +660,30 @@ Array [
           "accessory": Object {
             "action_id": "overflow_menu",
             "options": Array [
+              Object {
+                "text": Object {
+                  "emoji": true,
+                  "text": "➡️ ひとつ進む",
+                  "type": "plain_text",
+                },
+                "value": "rotate:1597200000000",
+              },
+              Object {
+                "text": Object {
+                  "emoji": true,
+                  "text": "⬅️ ひとつ戻る",
+                  "type": "plain_text",
+                },
+                "value": "unrotate:1597200000000",
+              },
+              Object {
+                "text": Object {
+                  "emoji": true,
+                  "text": "───────────────────",
+                  "type": "plain_text",
+                },
+                "value": "noop:1597200000000",
+              },
               Object {
                 "text": Object {
                   "emoji": true,

--- a/functions/src/__snapshots__/index.test.ts.snap
+++ b/functions/src/__snapshots__/index.test.ts.snap
@@ -717,30 +717,6 @@ Array [
               Object {
                 "text": Object {
                   "emoji": true,
-                  "text": "➡️ ひとつ進む",
-                  "type": "plain_text",
-                },
-                "value": "rotate:1597200000000",
-              },
-              Object {
-                "text": Object {
-                  "emoji": true,
-                  "text": "⬅️ ひとつ戻る",
-                  "type": "plain_text",
-                },
-                "value": "unrotate:1597200000000",
-              },
-              Object {
-                "text": Object {
-                  "emoji": true,
-                  "text": "───────────────────",
-                  "type": "plain_text",
-                },
-                "value": "noop:1597200000000",
-              },
-              Object {
-                "text": Object {
-                  "emoji": true,
                   "text": "削除",
                   "type": "plain_text",
                 },

--- a/functions/src/__snapshots__/index.test.ts.snap
+++ b/functions/src/__snapshots__/index.test.ts.snap
@@ -603,7 +603,7 @@ Array [
 ]
 `;
 
-exports[`functions slack delete rotation deletes the selected rotation from Firestore and posts that 1`] = `
+exports[`functions slack overflow menu actions delete deletes the selected rotation from Firestore and posts that 1`] = `
 Array [
   Array [
     Object {
@@ -617,7 +617,7 @@ Array [
 ]
 `;
 
-exports[`functions slack delete rotation posts 'already deleted' as ephemeral if the rotation not exist 1`] = `
+exports[`functions slack overflow menu actions delete posts 'already deleted' as ephemeral if the rotation not exist 1`] = `
 Array [
   Array [
     Object {

--- a/functions/src/__snapshots__/index.test.ts.snap
+++ b/functions/src/__snapshots__/index.test.ts.snap
@@ -627,8 +627,62 @@ Array [
       "user": "user-id",
     },
   ],
+  Array [
+    Object {
+      "channel": "channel-id",
+      "text": "このローテーションは削除済みです",
+      "token": "dummy-bot-token",
+      "user": "user-id",
+    },
+  ],
+  Array [
+    Object {
+      "channel": "channel-id",
+      "text": "このローテーションは削除済みです",
+      "token": "dummy-bot-token",
+      "user": "user-id",
+    },
+  ],
 ]
 `;
+
+exports[`functions slack overflow menu actions rotate posts 'already deleted' as ephemeral if the rotation not exist 1`] = `
+Array [
+  Array [
+    Object {
+      "channel": "channel-id",
+      "text": "このローテーションは削除済みです",
+      "token": "dummy-bot-token",
+      "user": "user-id",
+    },
+  ],
+]
+`;
+
+exports[`functions slack overflow menu actions rotate rotates the selected rotation and posts that 1`] = `Array []`;
+
+exports[`functions slack overflow menu actions unrotate posts 'already deleted' as ephemeral if the rotation not exist 1`] = `
+Array [
+  Array [
+    Object {
+      "channel": "channel-id",
+      "text": "このローテーションは削除済みです",
+      "token": "dummy-bot-token",
+      "user": "user-id",
+    },
+  ],
+  Array [
+    Object {
+      "channel": "channel-id",
+      "text": "このローテーションは削除済みです",
+      "token": "dummy-bot-token",
+      "user": "user-id",
+    },
+  ],
+]
+`;
+
+exports[`functions slack overflow menu actions unrotate unrotates the selected rotation and posts that 1`] = `Array []`;
 
 exports[`functions slack submit from SettingModal posts SettingSuccessMessage and creates a rotation on Firestore 1`] = `
 Array [

--- a/functions/src/__snapshots__/index.test.ts.snap
+++ b/functions/src/__snapshots__/index.test.ts.snap
@@ -21,7 +21,7 @@ Array [
               Object {
                 "text": Object {
                   "emoji": true,
-                  "text": "➡️ ひとつ進む",
+                  "text": "ひとつ進む",
                   "type": "plain_text",
                 },
                 "value": "rotate:rotation-1",
@@ -29,7 +29,7 @@ Array [
               Object {
                 "text": Object {
                   "emoji": true,
-                  "text": "⬅️ ひとつ戻る",
+                  "text": "ひとつ戻る",
                   "type": "plain_text",
                 },
                 "value": "unrotate:rotation-1",
@@ -85,7 +85,7 @@ Array [
               Object {
                 "text": Object {
                   "emoji": true,
-                  "text": "➡️ ひとつ進む",
+                  "text": "ひとつ進む",
                   "type": "plain_text",
                 },
                 "value": "rotate:rotation-2",
@@ -93,7 +93,7 @@ Array [
               Object {
                 "text": Object {
                   "emoji": true,
-                  "text": "⬅️ ひとつ戻る",
+                  "text": "ひとつ戻る",
                   "type": "plain_text",
                 },
                 "value": "unrotate:rotation-2",

--- a/functions/src/component.tsx
+++ b/functions/src/component.tsx
@@ -131,7 +131,8 @@ export const SettingSuccessMessage = ({
       </Section>
       <Section>
         <blockquote>
-          <Order rotation={rotation} />
+          {/* プレビューなので、次回 post 時の順序で表示する */}
+          <Order rotation={rotation.rotate()} />
         </blockquote>
         <OverflowMenu rotation={rotation} canRotate={false} />
       </Section>

--- a/functions/src/component.tsx
+++ b/functions/src/component.tsx
@@ -78,14 +78,28 @@ const Order = ({ rotation }: { readonly rotation: Rotation }) => (
   </Fragment>
 );
 
-const OverflowMenu = ({ rotation }: { readonly rotation: Rotation }) => (
+const OverflowMenu = ({
+  rotation,
+  canRotate,
+}: {
+  readonly rotation: Rotation;
+  readonly canRotate: boolean;
+}) => (
   <Overflow actionId={ID.OVERFLOW_MENU}>
-    <OverflowItem value={`rotate:${rotation.id}`}>➡️ ひとつ進む</OverflowItem>
-    <OverflowItem value={`unrotate:${rotation.id}`}>⬅️ ひとつ戻る</OverflowItem>
-    <OverflowItem value={`noop:${rotation.id}`}>
-      {/* 「削除」誤クリック防止のため、divider っぽい項目で区切る */}
-      ───────────────────
-    </OverflowItem>
+    {canRotate && (
+      <Fragment>
+        <OverflowItem value={`rotate:${rotation.id}`}>
+          ➡️ ひとつ進む
+        </OverflowItem>
+        <OverflowItem value={`unrotate:${rotation.id}`}>
+          ⬅️ ひとつ戻る
+        </OverflowItem>
+        <OverflowItem value={`noop:${rotation.id}`}>
+          {/* 「削除」誤クリック防止のため、divider っぽい項目で区切る */}
+          ───────────────────
+        </OverflowItem>
+      </Fragment>
+    )}
     <OverflowItem value={`delete:${rotation.id}`}>削除</OverflowItem>
   </Overflow>
 );
@@ -121,7 +135,7 @@ export const SettingSuccessMessage = ({
         <blockquote>
           <Order rotation={rotation} />
         </blockquote>
-        <OverflowMenu rotation={rotation} />
+        <OverflowMenu rotation={rotation} canRotate={false} />
       </Section>
     </Blocks>
   );
@@ -145,7 +159,7 @@ export const RotationMessage = ({
       </Section>
       <Section>
         <Order rotation={rotation} />
-        <OverflowMenu rotation={rotation} />
+        <OverflowMenu rotation={rotation} canRotate={true} />
       </Section>
     </Blocks>
   );

--- a/functions/src/component.tsx
+++ b/functions/src/component.tsx
@@ -80,6 +80,12 @@ const Order = ({ rotation }: { readonly rotation: Rotation }) => (
 
 const OverflowMenu = ({ rotation }: { readonly rotation: Rotation }) => (
   <Overflow actionId={ID.OVERFLOW_MENU}>
+    <OverflowItem value={`rotate:${rotation.id}`}>➡️ ひとつ進む</OverflowItem>
+    <OverflowItem value={`unrotate:${rotation.id}`}>⬅️ ひとつ戻る</OverflowItem>
+    <OverflowItem value={`noop:${rotation.id}`}>
+      {/* 「削除」誤クリック防止のため、divider っぽい項目で区切る */}
+      ───────────────────
+    </OverflowItem>
     <OverflowItem value={`delete:${rotation.id}`}>削除</OverflowItem>
   </Overflow>
 );

--- a/functions/src/component.tsx
+++ b/functions/src/component.tsx
@@ -88,11 +88,9 @@ const OverflowMenu = ({
   <Overflow actionId={ID.OVERFLOW_MENU}>
     {canRotate && (
       <Fragment>
-        <OverflowItem value={`rotate:${rotation.id}`}>
-          ➡️ ひとつ進む
-        </OverflowItem>
+        <OverflowItem value={`rotate:${rotation.id}`}>ひとつ進む</OverflowItem>
         <OverflowItem value={`unrotate:${rotation.id}`}>
-          ⬅️ ひとつ戻る
+          ひとつ戻る
         </OverflowItem>
         <OverflowItem value={`noop:${rotation.id}`}>
           {/* 「削除」誤クリック防止のため、divider っぽい項目で区切る */}

--- a/functions/src/cron.ts
+++ b/functions/src/cron.ts
@@ -12,7 +12,8 @@ export const cronHandler = (
   functions.logger.log("rotations", { rotations });
 
   for (const rotation of rotations) {
-    await postRotation(rotation);
-    await rotationStore.set(rotation.rotate());
+    const newRotation = rotation.rotate();
+    await rotationStore.set(newRotation);
+    await postRotation(newRotation);
   }
 };

--- a/functions/src/index.test.ts
+++ b/functions/src/index.test.ts
@@ -231,7 +231,7 @@ describe("functions", () => {
           const res = await postOverflowAction({
             text: {
               type: "plain_text",
-              text: "➡️ ひとつ進む",
+              text: "ひとつ進む",
               emoji: true,
             },
             value: "rotate:rotation-1",
@@ -251,7 +251,7 @@ describe("functions", () => {
           const res = await postOverflowAction({
             text: {
               type: "plain_text",
-              text: "➡️ ひとつ進む",
+              text: "ひとつ進む",
               emoji: true,
             },
             value: "rotate:rotation-not-exist",
@@ -268,7 +268,7 @@ describe("functions", () => {
           const res = await postOverflowAction({
             text: {
               type: "plain_text",
-              text: "⬅️ ひとつ戻る",
+              text: "ひとつ戻る",
               emoji: true,
             },
             value: "unrotate:rotation-1",
@@ -288,7 +288,7 @@ describe("functions", () => {
           const res = await postOverflowAction({
             text: {
               type: "plain_text",
-              text: "⬅️ ひとつ戻る",
+              text: "ひとつ戻る",
               emoji: true,
             },
             value: "unrotate:rotation-not-exist",

--- a/functions/src/index.test.ts
+++ b/functions/src/index.test.ts
@@ -42,6 +42,8 @@ describe("functions", () => {
 
   // Firestore
   const rotationsRef = admin.firestore().collection("rotations");
+  const getAllRotations = async () =>
+    (await rotationsRef.get()).docs.map((doc) => doc.data());
   beforeEach(async () => {
     // Prepare rotations in Firestore
     await Promise.all(
@@ -67,9 +69,7 @@ describe("functions", () => {
         expect(res.body).toEqual({}); // ack
         expect(client.views.open.mock.calls).toMatchSnapshot();
 
-        expect(
-          (await rotationsRef.get()).docs.map((doc) => doc.data())
-        ).toEqual(rotations);
+        expect(await getAllRotations()).toEqual(rotations);
       });
     });
 
@@ -170,9 +170,7 @@ describe("functions", () => {
         expect(res.body).toEqual({}); // ack
         expect(client.chat.postMessage.mock.calls).toMatchSnapshot();
 
-        expect(
-          (await rotationsRef.get()).docs.map((doc) => doc.data())
-        ).toEqual([
+        expect(await getAllRotations()).toEqual([
           {
             id: "1597200000000",
             channel: "channel-id",
@@ -241,9 +239,7 @@ describe("functions", () => {
           expect(res.body).toEqual({}); // ack
           expect(client.chat.postMessage.mock.calls).toMatchSnapshot();
 
-          expect(
-            (await rotationsRef.get()).docs.map((doc) => doc.data())
-          ).toEqual([
+          expect(await getAllRotations()).toEqual([
             { ...rotations[0], onDuty: "user-b" },
             rotations[1],
             rotations[2],
@@ -263,9 +259,7 @@ describe("functions", () => {
           expect(res.body).toEqual({}); // ack
           expect(client.chat.postEphemeral.mock.calls).toMatchSnapshot();
 
-          expect(
-            (await rotationsRef.get()).docs.map((doc) => doc.data())
-          ).toEqual(rotations);
+          expect(await getAllRotations()).toEqual(rotations);
         });
       });
 
@@ -282,9 +276,7 @@ describe("functions", () => {
           expect(res.body).toEqual({}); // ack
           expect(client.chat.postMessage.mock.calls).toMatchSnapshot();
 
-          expect(
-            (await rotationsRef.get()).docs.map((doc) => doc.data())
-          ).toEqual([
+          expect(await getAllRotations()).toEqual([
             { ...rotations[0], onDuty: "user-c" },
             rotations[1],
             rotations[2],
@@ -323,9 +315,9 @@ describe("functions", () => {
           expect(res.body).toEqual({}); // ack
           expect(client.chat.postMessage.mock.calls).toMatchSnapshot();
 
-          expect(
-            (await rotationsRef.get()).docs.map((doc) => doc.data())
-          ).toEqual(rotations.filter((r) => r.id !== "rotation-1"));
+          expect(await getAllRotations()).toEqual(
+            rotations.filter((r) => r.id !== "rotation-1")
+          );
         });
 
         it("posts 'already deleted' as ephemeral if the rotation not exist", async () => {
@@ -340,9 +332,7 @@ describe("functions", () => {
           expect(res.body).toEqual({}); // ack
           expect(client.chat.postEphemeral.mock.calls).toMatchSnapshot();
 
-          expect(
-            (await rotationsRef.get()).docs.map((doc) => doc.data())
-          ).toEqual(rotations);
+          expect(await getAllRotations()).toEqual(rotations);
         });
       });
     });
@@ -356,7 +346,7 @@ describe("functions", () => {
         timestamp: "2020-08-08T22:33:44.000Z", // Sun, 09 Aug 2020 07:33:44 JST
       });
       expect(client.chat.postMessage.mock.calls).toMatchSnapshot();
-      expect((await rotationsRef.get()).docs.map((doc) => doc.data())).toEqual([
+      expect(await getAllRotations()).toEqual([
         { ...rotations[0], onDuty: "user-b" },
         { ...rotations[1], onDuty: "user-p" },
         rotations[2],
@@ -369,9 +359,7 @@ describe("functions", () => {
         timestamp: "2020-08-09T22:33:44.000Z", // Mon, 10 Aug 2020 07:33:44 JST
       });
       expect(client.chat.postMessage.mock.calls).toEqual([]);
-      expect((await rotationsRef.get()).docs.map((doc) => doc.data())).toEqual(
-        rotations
-      );
+      expect(await getAllRotations()).toEqual(rotations);
     });
   });
 });

--- a/functions/src/index.test.ts
+++ b/functions/src/index.test.ts
@@ -228,6 +228,88 @@ describe("functions", () => {
           }),
         });
 
+      describe("rotate", () => {
+        it("rotates the selected rotation and posts that", async () => {
+          const res = await postOverflowAction({
+            text: {
+              type: "plain_text",
+              text: "➡️ ひとつ進む",
+              emoji: true,
+            },
+            value: "rotate:rotation-1",
+          });
+          expect(res.body).toEqual({}); // ack
+          expect(client.chat.postMessage.mock.calls).toMatchSnapshot();
+
+          expect(
+            (await rotationsRef.get()).docs.map((doc) => doc.data())
+          ).toEqual([
+            { ...rotations[0], onDuty: "user-b" },
+            rotations[1],
+            rotations[2],
+            rotations[3],
+          ]);
+        });
+
+        it("posts 'already deleted' as ephemeral if the rotation not exist", async () => {
+          const res = await postOverflowAction({
+            text: {
+              type: "plain_text",
+              text: "➡️ ひとつ進む",
+              emoji: true,
+            },
+            value: "rotate:rotation-not-exist",
+          });
+          expect(res.body).toEqual({}); // ack
+          expect(client.chat.postEphemeral.mock.calls).toMatchSnapshot();
+
+          expect(
+            (await rotationsRef.get()).docs.map((doc) => doc.data())
+          ).toEqual(rotations);
+        });
+      });
+
+      describe("unrotate", () => {
+        it("unrotates the selected rotation and posts that", async () => {
+          const res = await postOverflowAction({
+            text: {
+              type: "plain_text",
+              text: "⬅️ ひとつ戻る",
+              emoji: true,
+            },
+            value: "unrotate:rotation-1",
+          });
+          expect(res.body).toEqual({}); // ack
+          expect(client.chat.postMessage.mock.calls).toMatchSnapshot();
+
+          expect(
+            (await rotationsRef.get()).docs.map((doc) => doc.data())
+          ).toEqual([
+            { ...rotations[0], onDuty: "user-c" },
+            rotations[1],
+            rotations[2],
+            rotations[3],
+          ]);
+        });
+
+        it("posts 'already deleted' as ephemeral if the rotation not exist", async () => {
+          const res = await postOverflowAction({
+            text: {
+              type: "plain_text",
+              text: "⬅️ ひとつ戻る",
+              emoji: true,
+            },
+            value: "unrotate:rotation-not-exist",
+          });
+          expect(res.body).toEqual({}); // ack
+          expect(client.chat.postEphemeral.mock.calls).toMatchSnapshot();
+
+          expect(
+            (await rotationsRef.get()).docs.map((doc) => doc.data())
+          ).toEqual(rotations);
+        });
+      });
+
       describe("delete", () => {
         it("deletes the selected rotation from Firestore and posts that", async () => {
           const res = await postOverflowAction({

--- a/functions/src/index.test.ts
+++ b/functions/src/index.test.ts
@@ -176,7 +176,7 @@ describe("functions", () => {
             channel: "channel-id",
             members: ["user-a", "user-b", "user-c"],
             message: "てすてす\n\n*テスト*です",
-            onDuty: "user-a",
+            onDuty: "user-c",
             schedule: {
               days: [1, 3, 5],
               hour: 23,

--- a/functions/src/model/rotation.test.ts
+++ b/functions/src/model/rotation.test.ts
@@ -70,6 +70,32 @@ describe("Rotation", () => {
     });
   });
 
+  describe("unrotate", () => {
+    it("unrotates onDuty to the previous member", () => {
+      const original = Rotation.fromJSON(json);
+      const rotated = original.unrotate();
+      expect(rotated.onDuty).toBe("user-a");
+
+      expect(rotated).not.toBe(original);
+      expect(rotated.id).toBe(original.id);
+      expect(rotated.members).toEqual(original.members);
+      expect(rotated.channel).toBe(original.channel);
+      expect(rotated.schedule.toJSON()).toEqual(original.schedule.toJSON());
+    });
+
+    it("unrotates onDuty to the last member when onDuty was the first", () => {
+      const original = Rotation.fromJSON({ ...json, onDuty: "user-a" });
+      const rotated = original.unrotate();
+      expect(rotated.onDuty).toBe("user-c");
+
+      expect(rotated).not.toBe(original);
+      expect(rotated.id).toBe(original.id);
+      expect(rotated.members).toEqual(original.members);
+      expect(rotated.channel).toBe(original.channel);
+      expect(rotated.schedule.toJSON()).toEqual(original.schedule.toJSON());
+    });
+  });
+
   describe("getOrderedRestMembers", () => {
     it("returns non-onDuty members in the rotation order", () => {
       const rotation = Rotation.fromJSON(json);

--- a/functions/src/model/rotation.test.ts
+++ b/functions/src/model/rotation.test.ts
@@ -38,9 +38,9 @@ describe("Rotation", () => {
       expect(rotation.id).toBe("1597200000000");
     });
 
-    it("defaults to the first member for onDuty", () => {
+    it("defaults to the last member for onDuty", () => {
       const rotation = Rotation.fromJSON({ ...json, onDuty: undefined });
-      expect(rotation.onDuty).toBe(json.members[0]);
+      expect(rotation.onDuty).toBe("user-c");
     });
   });
 

--- a/functions/src/model/rotation.ts
+++ b/functions/src/model/rotation.ts
@@ -53,6 +53,14 @@ export class Rotation {
     });
   }
 
+  unrotate(): Rotation {
+    const index = this.members.indexOf(this.onDuty);
+    return new Rotation({
+      ...this,
+      onDuty: this.members[index - 1] ?? this.members[this.members.length - 1],
+    });
+  }
+
   getOrderedRestMembers(): readonly string[] {
     const index = this.members.indexOf(this.onDuty);
     return [...this.members.slice(index + 1), ...this.members.slice(0, index)];

--- a/functions/src/model/rotation.ts
+++ b/functions/src/model/rotation.ts
@@ -9,7 +9,9 @@ export type RotationJSON = Omit<RotationArgs, "schedule"> & {
 export class Rotation {
   readonly id: string;
   readonly members: readonly string[];
-  readonly onDuty: string; // 担当者の user_id。members の中の 1 人
+  // 担当者の user_id。members の中の 1 人。
+  // store には、「最後に post したときの担当者」の状態で保存する。「次の担当者」ではない。
+  readonly onDuty: string;
   readonly message: string;
   readonly channel: string;
   readonly schedule: Schedule;
@@ -38,7 +40,8 @@ export class Rotation {
     return new Rotation({
       id: json.id ?? Date.now().toString(),
       members: json.members,
-      onDuty: json.onDuty ?? json.members[0],
+      // 初回 post 時に先頭のメンバーを onDuty にしたいので、末尾のメンバーを割り当てておく
+      onDuty: json.onDuty ?? json.members[json.members.length - 1],
       message: json.message,
       channel: json.channel,
       schedule: Schedule.fromJSON(json.schedule),

--- a/functions/src/slack.ts
+++ b/functions/src/slack.ts
@@ -123,7 +123,19 @@ export const createSlackApp = (
           }
           break;
         case "unrotate":
-          // TODO
+          try {
+            const newRotation = rotation.unrotate();
+            await rotationStore.set(newRotation);
+            await app.client.chat.update({
+              token: config.slack.bot_token,
+              channel: channelId,
+              ts: body.container.message_ts,
+              text: newRotation.message,
+              blocks: RotationMessage({ rotation: newRotation }),
+            });
+          } catch (error) {
+            functions.logger.error("error", { error });
+          }
           break;
         case "noop":
           break;

--- a/functions/src/slack.ts
+++ b/functions/src/slack.ts
@@ -91,27 +91,53 @@ export const createSlackApp = (
 
       const userId = body.user.id;
       const [type, rotationId] = action.selected_option.value.split(":");
+      const rotation = await rotationStore.get(rotationId);
+      if (!rotation) {
+        try {
+          await app.client.chat.postEphemeral({
+            token: config.slack.bot_token,
+            channel: channelId,
+            text: "このローテーションは削除済みです",
+            user: userId,
+          });
+        } catch (error) {
+          functions.logger.error("error", { error });
+        }
+        return;
+      }
+
       switch (type) {
+        case "rotate":
+          try {
+            const newRotation = rotation.rotate();
+            await rotationStore.set(newRotation);
+            await app.client.chat.update({
+              token: config.slack.bot_token,
+              channel: channelId,
+              ts: body.container.message_ts,
+              text: newRotation.message,
+              blocks: RotationMessage({ rotation: newRotation }),
+            });
+          } catch (error) {
+            functions.logger.error("error", { error });
+          }
+          break;
+        case "unrotate":
+          // TODO
+          break;
+        case "noop":
+          break;
         case "delete":
           try {
-            if (await rotationStore.has(rotationId)) {
-              await rotationStore.delete(rotationId);
-              // respond() だと reply_broadcast が効かない？
-              await app.client.chat.postMessage({
-                token: config.slack.bot_token,
-                channel: channelId,
-                text: `<@${userId}> さんがこのローテーションを削除しました 👋`,
-                thread_ts: body.container.message_ts,
-                reply_broadcast: true,
-              });
-            } else {
-              await app.client.chat.postEphemeral({
-                token: config.slack.bot_token,
-                channel: channelId,
-                text: "このローテーションは削除済みです",
-                user: userId,
-              });
-            }
+            await rotationStore.delete(rotationId);
+            // respond() だと reply_broadcast が効かない？
+            await app.client.chat.postMessage({
+              token: config.slack.bot_token,
+              channel: channelId,
+              text: `<@${userId}> さんがこのローテーションを削除しました 👋`,
+              thread_ts: body.container.message_ts,
+              reply_broadcast: true,
+            });
           } catch (error) {
             functions.logger.error("error", { error });
           }

--- a/functions/src/store.ts
+++ b/functions/src/store.ts
@@ -11,6 +11,12 @@ export class RotationStore {
       .set(rotation.toJSON());
   }
 
+  async get(rotationId: string): Promise<Rotation | null> {
+    const doc = await this.db.collection("rotations").doc(rotationId).get();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return doc.exists ? Rotation.fromJSON(doc.data() as any) : null;
+  }
+
   async getBySchedule(schedule: Schedule): Promise<readonly Rotation[]> {
     if (schedule.days.length !== 1) {
       throw new Error("Length of schedule.days must be 1");
@@ -24,11 +30,6 @@ export class RotationStore {
       .get();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return snapshot.docs.map((doc) => Rotation.fromJSON(doc.data() as any));
-  }
-
-  async has(rotationId: string): Promise<boolean> {
-    const doc = await this.db.collection("rotations").doc(rotationId).get();
-    return doc.exists;
   }
 
   async delete(rotationId: string): Promise<void> {


### PR DESCRIPTION
Close #5 

- […] に `ひとつ進む` `ひとつ戻る` の項目を追加
    - クリックすると担当者が前後に移動し、post したメッセージがまるごと上書きされる
    - ただし、設定完了メッセージのメニューには、この項目は表示しない
        - 対応しようと思うと、設定完了メッセージが否かによって、上書きするメッセージを変えなければならないので面倒
- [...] の `削除` の誤クリックを防ぐため、`────` で区切りを入れる
    - divider 的な項目は Slack に用意されていないようなので、罫線で擬似的に表現
    - この区切りはクリックしても何も起こらない
- Firestore 上の `onDuty` の状態に一貫性がなかったので、「最後に post したときの状態」に統一
    - 破壊的変更なので、既存のデータは要マイグレーション

![Aug-14-2020 02-20-04](https://user-images.githubusercontent.com/6268183/90166193-cbc96480-ddd4-11ea-80b5-124ef4f2b17a.gif)