### PR TITLE
メンバー全員にメンションするか、担当者だけにするか、選択可能にする

### DIFF
--- a/functions/src/__snapshots__/component.test.tsx.snap
+++ b/functions/src/__snapshots__/component.test.tsx.snap
@@ -1,6 +1,67 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`RotationMessage renders correctly 1`] = `
+exports[`RotationMessage renders correctly when mentionAll: false 1`] = `
+Array [
+  Object {
+    "text": Object {
+      "text": "message line 1
+message line 2
+",
+      "type": "mrkdwn",
+      "verbatim": false,
+    },
+    "type": "section",
+  },
+  Object {
+    "accessory": Object {
+      "action_id": "overflow_menu",
+      "options": Array [
+        Object {
+          "text": Object {
+            "emoji": true,
+            "text": "ひとつ進む",
+            "type": "plain_text",
+          },
+          "value": "rotate:rotation-id",
+        },
+        Object {
+          "text": Object {
+            "emoji": true,
+            "text": "ひとつ戻る",
+            "type": "plain_text",
+          },
+          "value": "unrotate:rotation-id",
+        },
+        Object {
+          "text": Object {
+            "emoji": true,
+            "text": "───────────────────",
+            "type": "plain_text",
+          },
+          "value": "noop:rotation-id",
+        },
+        Object {
+          "text": Object {
+            "emoji": true,
+            "text": "削除",
+            "type": "plain_text",
+          },
+          "value": "delete:rotation-id",
+        },
+      ],
+      "type": "overflow",
+    },
+    "text": Object {
+      "text": "👑 <@user-b|>→ @userC → @userA",
+      "type": "mrkdwn",
+      "verbatim": true,
+    },
+    "type": "section",
+  },
+]
+`;
+
+exports[`RotationMessage renders correctly when mentionAll: true 1`] = `
 Array [
   Object {
     "text": Object {
@@ -563,7 +624,55 @@ Object {
 }
 `;
 
-exports[`SettingSuccessMessage renders correctly 1`] = `
+exports[`SettingSuccessMessage renders correctly when mentionAll: false 1`] = `
+Array [
+  Object {
+    "text": Object {
+      "text": "<@user-x|>さんがローテーションを設定しました！
+
+火曜の 23:45 に 👇 のような感じでお知らせします",
+      "type": "mrkdwn",
+      "verbatim": true,
+    },
+    "type": "section",
+  },
+  Object {
+    "text": Object {
+      "text": "&gt; message line 1
+&gt; message line 2
+",
+      "type": "mrkdwn",
+      "verbatim": false,
+    },
+    "type": "section",
+  },
+  Object {
+    "accessory": Object {
+      "action_id": "overflow_menu",
+      "options": Array [
+        Object {
+          "text": Object {
+            "emoji": true,
+            "text": "削除",
+            "type": "plain_text",
+          },
+          "value": "delete:rotation-id",
+        },
+      ],
+      "type": "overflow",
+    },
+    "text": Object {
+      "text": "&gt; 👑 <@user-c|>→ @userA → @userB
+&gt; ",
+      "type": "mrkdwn",
+      "verbatim": true,
+    },
+    "type": "section",
+  },
+]
+`;
+
+exports[`SettingSuccessMessage renders correctly when mentionAll: true 1`] = `
 Array [
   Object {
     "text": Object {

--- a/functions/src/__snapshots__/component.test.tsx.snap
+++ b/functions/src/__snapshots__/component.test.tsx.snap
@@ -501,6 +501,46 @@ Object {
       "optional": false,
       "type": "input",
     },
+    Object {
+      "block_id": "mention_all",
+      "element": Object {
+        "action_id": "mention_all",
+        "initial_option": Object {
+          "text": Object {
+            "text": "全員にメンションする",
+            "type": "mrkdwn",
+            "verbatim": true,
+          },
+          "value": "true",
+        },
+        "options": Array [
+          Object {
+            "text": Object {
+              "text": "全員にメンションする",
+              "type": "mrkdwn",
+              "verbatim": true,
+            },
+            "value": "true",
+          },
+          Object {
+            "text": Object {
+              "text": "担当者だけにメンションする",
+              "type": "mrkdwn",
+              "verbatim": true,
+            },
+            "value": "false",
+          },
+        ],
+        "type": "radio_buttons",
+      },
+      "label": Object {
+        "emoji": true,
+        "text": "メンション",
+        "type": "plain_text",
+      },
+      "optional": false,
+      "type": "input",
+    },
   ],
   "callback_id": "submit_callback",
   "close": Object {

--- a/functions/src/__snapshots__/index.test.ts.snap
+++ b/functions/src/__snapshots__/index.test.ts.snap
@@ -578,6 +578,46 @@ Array [
             "optional": false,
             "type": "input",
           },
+          Object {
+            "block_id": "mention_all",
+            "element": Object {
+              "action_id": "mention_all",
+              "initial_option": Object {
+                "text": Object {
+                  "text": "全員にメンションする",
+                  "type": "mrkdwn",
+                  "verbatim": true,
+                },
+                "value": "true",
+              },
+              "options": Array [
+                Object {
+                  "text": Object {
+                    "text": "全員にメンションする",
+                    "type": "mrkdwn",
+                    "verbatim": true,
+                  },
+                  "value": "true",
+                },
+                Object {
+                  "text": Object {
+                    "text": "担当者だけにメンションする",
+                    "type": "mrkdwn",
+                    "verbatim": true,
+                  },
+                  "value": "false",
+                },
+              ],
+              "type": "radio_buttons",
+            },
+            "label": Object {
+              "emoji": true,
+              "text": "メンション",
+              "type": "plain_text",
+            },
+            "optional": false,
+            "type": "input",
+          },
         ],
         "callback_id": "submit_callback",
         "close": Object {

--- a/functions/src/component.test.tsx
+++ b/functions/src/component.test.tsx
@@ -6,7 +6,7 @@ import {
 } from "./component";
 import { Rotation } from "./model/rotation";
 
-const rotation = Rotation.fromJSON({
+const rotationMentionAll = Rotation.fromJSON({
   id: "rotation-id",
   members: ["user-a", "user-b", "user-c"],
   onDuty: "user-b",
@@ -20,6 +20,20 @@ const rotation = Rotation.fromJSON({
   mentionAll: true,
 });
 
+const rotationNotMentionAll = Rotation.fromJSON({
+  id: "rotation-id",
+  members: ["user-a", "user-b", "user-c"],
+  onDuty: "user-b",
+  message: "message line 1\nmessage line 2",
+  channel: "channel-id",
+  schedule: {
+    days: [2],
+    hour: 23,
+    minute: 45,
+  },
+  mentionAll: false,
+});
+
 describe("SettingModal", () => {
   it("renders correctly", () => {
     expect(SettingModal({ channelId: "channel-id" })).toMatchSnapshot();
@@ -27,18 +41,46 @@ describe("SettingModal", () => {
 });
 
 describe("SettingSuccessMessage", () => {
-  it("renders correctly", () => {
+  it("renders correctly when mentionAll: true", () => {
     expect(
       SettingSuccessMessage({
-        rotation,
+        rotation: rotationMentionAll,
         userId: "user-x",
+        userNameDict: null,
+      })
+    ).toMatchSnapshot();
+  });
+  it("renders correctly when mentionAll: false", () => {
+    expect(
+      SettingSuccessMessage({
+        rotation: rotationNotMentionAll,
+        userId: "user-x",
+        userNameDict: {
+          "user-a": "userA",
+          "user-b": "userB",
+          "user-c": "userC",
+        },
       })
     ).toMatchSnapshot();
   });
 });
 
 describe("RotationMessage", () => {
-  it("renders correctly", () => {
-    expect(RotationMessage({ rotation })).toMatchSnapshot();
+  it("renders correctly when mentionAll: true", () => {
+    expect(
+      RotationMessage({ rotation: rotationMentionAll, userNameDict: null })
+    ).toMatchSnapshot();
+  });
+  it("renders correctly when mentionAll: false", () => {
+    expect(
+      RotationMessage({
+        rotation: rotationNotMentionAll,
+        userNameDict: {
+          "user-a": "userA",
+          "user-b": "userB",
+          "user-c": "userC",
+        },
+      })
+    ).toMatchSnapshot();
   });
 });

--- a/functions/src/component.test.tsx
+++ b/functions/src/component.test.tsx
@@ -17,6 +17,7 @@ const rotation = Rotation.fromJSON({
     hour: 23,
     minute: 45,
   },
+  mentionAll: true,
 });
 
 describe("SettingModal", () => {

--- a/functions/src/component.tsx
+++ b/functions/src/component.tsx
@@ -14,6 +14,8 @@ import {
   Mrkdwn,
   Overflow,
   OverflowItem,
+  RadioButtonGroup,
+  RadioButton,
 } from "@speee-js/jsx-slack";
 import { Rotation } from "./model/rotation";
 import { INTERVAL_MINUTES, DAY_STRINGS } from "./model/schedule";
@@ -26,6 +28,7 @@ export const ID = {
   DAYS: "days",
   HOUR: "hour",
   MINUTE: "minute",
+  MENTION_ALL: "mention_all",
   OVERFLOW_MENU: "overflow_menu",
 } as const;
 
@@ -62,6 +65,16 @@ export const SettingModal = ({
           return <Option value={minute}>{minute}分</Option>;
         })}
       </Select>
+      <RadioButtonGroup
+        id={ID.MENTION_ALL}
+        name={ID.MENTION_ALL}
+        required
+        label="メンション"
+        value="true"
+      >
+        <RadioButton value="true">全員にメンションする</RadioButton>
+        <RadioButton value="false">担当者だけにメンションする</RadioButton>
+      </RadioButtonGroup>
       <Input type="submit" value="設定する" />
     </Modal>
   );

--- a/functions/src/component.tsx
+++ b/functions/src/component.tsx
@@ -79,13 +79,25 @@ export const SettingModal = ({
     </Modal>
   );
 
-const Order = ({ rotation }: { readonly rotation: Rotation }) => (
+const Order = ({
+  rotation,
+  userNameDict,
+}: {
+  readonly rotation: Rotation;
+  readonly userNameDict: Record<string, string> | null;
+}) => (
   <Fragment>
     👑 <a href={`@${rotation.onDuty}`} />
     {rotation.getOrderedRestMembers().map((member) => (
       <Fragment>
         {" → "}
-        <a href={`@${member}`} />
+        {/* 念のため、条件に !userNameDict を含めてはいるが、
+            mentionAll が false の場合は、本当は userNameDict が存在するはず */}
+        {rotation.mentionAll || !userNameDict ? (
+          <a href={`@${member}`} />
+        ) : (
+          `@${userNameDict[member]}`
+        )}
       </Fragment>
     ))}
   </Fragment>
@@ -120,9 +132,11 @@ type Blocks = KnownBlock[];
 export const SettingSuccessMessage = ({
   rotation,
   userId,
+  userNameDict,
 }: {
   readonly rotation: Rotation;
   readonly userId: string;
+  readonly userNameDict: Record<string, string> | null;
 }): Blocks =>
   JSXSlack(
     <Blocks>
@@ -145,7 +159,7 @@ export const SettingSuccessMessage = ({
       <Section>
         <blockquote>
           {/* プレビューなので、次回 post 時の順序で表示する */}
-          <Order rotation={rotation.rotate()} />
+          <Order rotation={rotation.rotate()} userNameDict={userNameDict} />
         </blockquote>
         <OverflowMenu rotation={rotation} canRotate={false} />
       </Section>
@@ -154,8 +168,10 @@ export const SettingSuccessMessage = ({
 
 export const RotationMessage = ({
   rotation,
+  userNameDict,
 }: {
   readonly rotation: Rotation;
+  readonly userNameDict: Record<string, string> | null;
 }): Blocks =>
   JSXSlack(
     <Blocks>
@@ -170,7 +186,7 @@ export const RotationMessage = ({
         </Mrkdwn>
       </Section>
       <Section>
-        <Order rotation={rotation} />
+        <Order rotation={rotation} userNameDict={userNameDict} />
         <OverflowMenu rotation={rotation} canRotate={true} />
       </Section>
     </Blocks>

--- a/functions/src/index.test.ts
+++ b/functions/src/index.test.ts
@@ -160,6 +160,19 @@ describe("functions", () => {
                       ],
                     },
                   },
+                  mention_all: {
+                    mention_all: {
+                      type: "radio_buttons",
+                      selected_option: {
+                        text: {
+                          type: "mrkdwn",
+                          text: "全員にメンションする",
+                          verbatim: true,
+                        },
+                        value: "true",
+                      },
+                    },
+                  },
                 },
               },
               // ...snip

--- a/functions/src/index.test.ts
+++ b/functions/src/index.test.ts
@@ -182,6 +182,7 @@ describe("functions", () => {
               hour: 23,
               minute: 45,
             },
+            mentionAll: true,
           },
           ...rotations,
         ]);

--- a/functions/src/model/rotation.test.ts
+++ b/functions/src/model/rotation.test.ts
@@ -13,6 +13,7 @@ describe("Rotation", () => {
       hour: 23,
       minute: 45,
     },
+    mentionAll: true,
   };
 
   describe("toJSON", () => {
@@ -30,6 +31,7 @@ describe("Rotation", () => {
       expect(rotation.onDuty).toBe(json.onDuty);
       expect(rotation.channel).toBe(json.channel);
       expect(rotation.schedule.toJSON()).toEqual(json.schedule);
+      expect(rotation.mentionAll).toBe(json.mentionAll);
     });
 
     it("defaults to unix timestamp for id", () => {
@@ -55,6 +57,7 @@ describe("Rotation", () => {
       expect(rotated.members).toEqual(original.members);
       expect(rotated.channel).toBe(original.channel);
       expect(rotated.schedule.toJSON()).toEqual(original.schedule.toJSON());
+      expect(rotated.mentionAll).toBe(json.mentionAll);
     });
 
     it("rotates onDuty to the first member when onDuty was the last", () => {
@@ -67,6 +70,7 @@ describe("Rotation", () => {
       expect(rotated.members).toEqual(original.members);
       expect(rotated.channel).toBe(original.channel);
       expect(rotated.schedule.toJSON()).toEqual(original.schedule.toJSON());
+      expect(rotated.mentionAll).toBe(json.mentionAll);
     });
   });
 
@@ -81,6 +85,7 @@ describe("Rotation", () => {
       expect(rotated.members).toEqual(original.members);
       expect(rotated.channel).toBe(original.channel);
       expect(rotated.schedule.toJSON()).toEqual(original.schedule.toJSON());
+      expect(rotated.mentionAll).toBe(json.mentionAll);
     });
 
     it("unrotates onDuty to the last member when onDuty was the first", () => {
@@ -93,6 +98,7 @@ describe("Rotation", () => {
       expect(rotated.members).toEqual(original.members);
       expect(rotated.channel).toBe(original.channel);
       expect(rotated.schedule.toJSON()).toEqual(original.schedule.toJSON());
+      expect(rotated.mentionAll).toBe(json.mentionAll);
     });
   });
 

--- a/functions/src/model/rotation.ts
+++ b/functions/src/model/rotation.ts
@@ -15,6 +15,7 @@ export class Rotation {
   readonly message: string;
   readonly channel: string;
   readonly schedule: Schedule;
+  readonly mentionAll: boolean;
 
   private constructor(args: RotationArgs) {
     this.id = args.id;
@@ -23,6 +24,7 @@ export class Rotation {
     this.message = args.message;
     this.channel = args.channel;
     this.schedule = args.schedule;
+    this.mentionAll = args.mentionAll;
   }
 
   toJSON(): RotationJSON {
@@ -33,6 +35,7 @@ export class Rotation {
       message: this.message,
       channel: this.channel,
       schedule: this.schedule.toJSON(),
+      mentionAll: this.mentionAll,
     };
   }
 
@@ -45,6 +48,7 @@ export class Rotation {
       message: json.message,
       channel: json.channel,
       schedule: Schedule.fromJSON(json.schedule),
+      mentionAll: json.mentionAll,
     });
   }
 

--- a/functions/src/slack.ts
+++ b/functions/src/slack.ts
@@ -61,7 +61,9 @@ export const createSlackApp = (
           view.state.values[ID.MINUTE][ID.MINUTE].selected_option.value
         ),
       },
-      mentionAll: true, // TODO
+      mentionAll: JSON.parse(
+        view.state.values[ID.MENTION_ALL][ID.MENTION_ALL].selected_option.value
+      ),
     });
 
     await rotationStore.set(rotation);

--- a/functions/src/slack.ts
+++ b/functions/src/slack.ts
@@ -28,6 +28,29 @@ export const createSlackApp = (
     token: config.slack.bot_token,
   });
 
+  /**
+   * { [user_id]: user_name } の辞書を返す
+   */
+  const getUserNameDict = async (): Promise<Record<string, string> | null> => {
+    try {
+      const json = await app.client.users.list({
+        token: config.slack.bot_token,
+      });
+      // @ts-ignore
+      return json.members.reduce(
+        // @ts-ignore
+        (acc, { id, profile }) => ({
+          ...acc,
+          [id]: profile.display_name || profile.real_name,
+        }),
+        {}
+      );
+    } catch (error) {
+      functions.logger.error("error", { error });
+    }
+    return null;
+  };
+
   app.command("/rota", async ({ ack, body, context }) => {
     await ack();
 
@@ -69,12 +92,13 @@ export const createSlackApp = (
     await rotationStore.set(rotation);
 
     const userId = body.user.id;
+    const userNameDict = rotation.mentionAll ? null : await getUserNameDict();
     try {
       await app.client.chat.postMessage({
         token: config.slack.bot_token,
         channel: rotation.channel,
         text: `<@${userId}> さんがローテーションを作成しました！`,
-        blocks: SettingSuccessMessage({ rotation, userId }),
+        blocks: SettingSuccessMessage({ rotation, userId, userNameDict }),
       });
     } catch (error) {
       functions.logger.error("error", { error });
@@ -114,12 +138,15 @@ export const createSlackApp = (
           try {
             const newRotation = rotation.rotate();
             await rotationStore.set(newRotation);
+            const userNameDict = newRotation.mentionAll
+              ? null
+              : await getUserNameDict();
             await app.client.chat.update({
               token: config.slack.bot_token,
               channel: channelId,
               ts: body.container.message_ts,
               text: newRotation.message,
-              blocks: RotationMessage({ rotation: newRotation }),
+              blocks: RotationMessage({ rotation: newRotation, userNameDict }),
             });
           } catch (error) {
             functions.logger.error("error", { error });
@@ -129,12 +156,15 @@ export const createSlackApp = (
           try {
             const newRotation = rotation.unrotate();
             await rotationStore.set(newRotation);
+            const userNameDict = newRotation.mentionAll
+              ? null
+              : await getUserNameDict();
             await app.client.chat.update({
               token: config.slack.bot_token,
               channel: channelId,
               ts: body.container.message_ts,
               text: newRotation.message,
-              blocks: RotationMessage({ rotation: newRotation }),
+              blocks: RotationMessage({ rotation: newRotation, userNameDict }),
             });
           } catch (error) {
             functions.logger.error("error", { error });
@@ -166,12 +196,13 @@ export const createSlackApp = (
   );
 
   const postRotation = async (rotation: Rotation): Promise<void> => {
+    const userNameDict = rotation.mentionAll ? null : await getUserNameDict();
     try {
       await app.client.chat.postMessage({
         token: config.slack.bot_token,
         channel: rotation.channel,
         text: rotation.message,
-        blocks: RotationMessage({ rotation }),
+        blocks: RotationMessage({ rotation, userNameDict }),
       });
     } catch (error) {
       functions.logger.error("error", { error });

--- a/functions/src/slack.ts
+++ b/functions/src/slack.ts
@@ -61,6 +61,7 @@ export const createSlackApp = (
           view.state.values[ID.MINUTE][ID.MINUTE].selected_option.value
         ),
       },
+      mentionAll: true, // TODO
     });
 
     await rotationStore.set(rotation);

--- a/functions/src/test-helper.ts
+++ b/functions/src/test-helper.ts
@@ -44,6 +44,7 @@ export const rotations: readonly RotationJSON[] = [
       hour: 7,
       minute: 35,
     },
+    mentionAll: true,
   },
   {
     id: "rotation-2",
@@ -56,6 +57,7 @@ export const rotations: readonly RotationJSON[] = [
       hour: 7,
       minute: 35,
     },
+    mentionAll: false,
   },
   {
     id: "rotation-3",
@@ -68,6 +70,7 @@ export const rotations: readonly RotationJSON[] = [
       hour: 22,
       minute: 35,
     },
+    mentionAll: true,
   },
   {
     id: "rotation-4",
@@ -80,5 +83,6 @@ export const rotations: readonly RotationJSON[] = [
       hour: 7,
       minute: 35,
     },
+    mentionAll: false,
   },
 ];


### PR DESCRIPTION
Close #3

設定モーダルにラジオボタンを追加。
（ファーストビューだと見切れていてわかりにくいが 😇）

<img width="540" alt="Slack___rota-test___まこなこ" src="https://user-images.githubusercontent.com/6268183/90794072-4ea76d80-e347-11ea-8e3d-ae4b2c3d37e7.png">

**担当者だけにメンションする** を選択した場合、こんな感じ ⬇️ の表示になる。

<img width="673" alt="Slack___rota-test___まこなこ" src="https://user-images.githubusercontent.com/6268183/90795343-e3f73180-e348-11ea-8dd3-4cb777f7a662.png">

Firestore 上では、`mentionAll` という名前の boolean フィールドが追加される。要手動マイグレーション。

また、Slack アプリには `users:read` 権限が必要。