### PR TITLE
Slack の mrkdwn フォーマットでメッセージを書けるようにする

### DIFF
--- a/functions/src/__tests__/__snapshots__/component.test.tsx.snap
+++ b/functions/src/__tests__/__snapshots__/component.test.tsx.snap
@@ -127,6 +127,11 @@ Object {
       "block_id": "members",
       "element": Object {
         "action_id": "members",
+        "placeholder": Object {
+          "emoji": true,
+          "text": "ローテーションさせる順番で選択してください",
+          "type": "plain_text",
+        },
         "type": "multi_users_select",
       },
       "label": Object {
@@ -142,6 +147,11 @@ Object {
       "element": Object {
         "action_id": "message",
         "multiline": true,
+        "placeholder": Object {
+          "emoji": false,
+          "text": "お知らせする本文です。Slack の mrkdwn が使えます",
+          "type": "plain_text",
+        },
         "type": "plain_text_input",
       },
       "label": Object {
@@ -214,6 +224,11 @@ Object {
             "value": "6",
           },
         ],
+        "placeholder": Object {
+          "emoji": true,
+          "text": "複数選択可能です",
+          "type": "plain_text",
+        },
         "type": "multi_static_select",
       },
       "label": Object {

--- a/functions/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/functions/src/__tests__/__snapshots__/index.test.ts.snap
@@ -143,6 +143,11 @@ Array [
             "block_id": "members",
             "element": Object {
               "action_id": "members",
+              "placeholder": Object {
+                "emoji": true,
+                "text": "ローテーションさせる順番で選択してください",
+                "type": "plain_text",
+              },
               "type": "multi_users_select",
             },
             "label": Object {
@@ -158,6 +163,11 @@ Array [
             "element": Object {
               "action_id": "message",
               "multiline": true,
+              "placeholder": Object {
+                "emoji": false,
+                "text": "お知らせする本文です。Slack の mrkdwn が使えます",
+                "type": "plain_text",
+              },
               "type": "plain_text_input",
             },
             "label": Object {
@@ -230,6 +240,11 @@ Array [
                   "value": "6",
                 },
               ],
+              "placeholder": Object {
+                "emoji": true,
+                "text": "複数選択可能です",
+                "type": "plain_text",
+              },
               "type": "multi_static_select",
             },
             "label": Object {

--- a/functions/src/component.tsx
+++ b/functions/src/component.tsx
@@ -45,10 +45,24 @@ export const SettingModal = ({
         required
         multiple
         label="メンバー"
+        placeholder="ローテーションさせる順番で選択してください"
       />
-      <Textarea id={ID.MESSAGE} name={ID.MESSAGE} required label="メッセージ" />
+      <Textarea
+        id={ID.MESSAGE}
+        name={ID.MESSAGE}
+        required
+        label="メッセージ"
+        placeholder="お知らせする本文です。Slack の mrkdwn が使えます"
+      />
       <Input type="hidden" name={ID.CHANNEL} value={channelId} />
-      <Select id={ID.DAYS} name={ID.DAYS} required multiple label="曜日">
+      <Select
+        id={ID.DAYS}
+        name={ID.DAYS}
+        required
+        multiple
+        label="曜日"
+        placeholder="複数選択可能です"
+      >
         {DAY_STRINGS.map((s, i) => {
           return <Option value={i.toString()}>{s}曜</Option>;
         })}


### PR DESCRIPTION
jsx-slack の [`<Mrkdwn verbatim={false}>`](https://github.com/speee/jsx-slack/blob/v2.4.0/docs/block-elements.md) だと、 `<https://example.com|Example Text>` 形式のリンクが表示できない。`<` `>` が `&lt;` `&gt;` にエスケープされるので。

そこで、https://github.com/speee/jsx-slack/issues/160#issuecomment-625598213 で示されている方法を使って、そのまま表示するようにする。

Slack の `mrkdwn` フォーマットについては以下のドキュメントを参照。普通の Markdown と結構違うのでややこしい 😇

- [Formatting text for app surfaces | Slack](https://api.slack.com/reference/surfaces/formatting#basics)

## 例

<img width="541" alt="Slack___rota-test___まこなこ" src="https://user-images.githubusercontent.com/6268183/90898434-938fda80-e401-11ea-978f-3e06263009f9.png">

<img width="675" alt="Slack___rota-test___まこなこ" src="https://user-images.githubusercontent.com/6268183/90898320-6f33fe00-e401-11ea-9dc8-ae34a225b9be.png">