### PR TITLE
外部からの Firestore アクセスをすべて拒否する

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,18 +1,8 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
-
-    // This rule allows anyone with your database reference to view, edit,
-    // and delete all data in your Firestore database. It is useful for getting
-    // started, but it is configured to expire after 30 days because it
-    // leaves your app open to attackers. At that time, all client
-    // requests to your Firestore database will be denied.
-    //
-    // Make sure to write security rules for your app before that time, or else
-    // all client requests to your Firestore database will be denied until you Update
-    // your rules
     match /{document=**} {
-      allow read, write: if request.time < timestamp.date(2020, 9, 3);
+      allow read, write: if false;
     }
   }
 }


### PR DESCRIPTION
[Cloud Functions による Cloud Firestore の拡張  |  Firebase](https://firebase.google.com/docs/firestore/extend-with-functions?hl=ja#data_outside_the_trigger_event)

> 注: Cloud Functions で実行される読み取りと書き込みは、セキュリティ ルールで制御されずに、データベースの任意の部分にアクセスできます。

[Cloud Firestore Security Rules allow write only from Firebase function - Stack Overflow](https://stackoverflow.com/a/51405783/13983344)

> If you just want your backend to read and write some part of your database but none of your mobile client apps, simply reject access to all clients entirely, and let the Admin SDK do its work.

とのことなので、`firestore.rules` 上ではすべて拒否しておけばよい。

下のドキュメントの「デフォルト ルール: ロックモード」と同じ内容にしておく。

[基本的なセキュリティ ルール  |  Firebase](https://firebase.google.com/docs/rules/basics?authuser=0)

`$ firebase deploy --only firestore` で実際にルールを反映。