### PR TITLE
メッセージ中のリンクの unfurl（展開プレビュー）を無効にする

### DIFF
--- a/functions/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/functions/src/__tests__/__snapshots__/index.test.ts.snap
@@ -63,6 +63,7 @@ Array [
       "channel": "channel-1",
       "text": "rotation-1 message",
       "token": "dummy-bot-token",
+      "unfurl_links": false,
     },
   ],
   Array [
@@ -126,6 +127,7 @@ Array [
       "channel": "channel-2",
       "text": "rotation-2 message",
       "token": "dummy-bot-token",
+      "unfurl_links": false,
     },
   ],
 ]
@@ -789,6 +791,7 @@ Array [
       "channel": "channel-id",
       "text": "<@user-id> さんがローテーションを作成しました！",
       "token": "dummy-bot-token",
+      "unfurl_links": false,
     },
   ],
 ]

--- a/functions/src/slack.ts
+++ b/functions/src/slack.ts
@@ -99,6 +99,7 @@ export const createSlackApp = (
         channel: rotation.channel,
         text: `<@${userId}> さんがローテーションを作成しました！`,
         blocks: CreateSuccessMessage({ rotation, userId, userNameDict }),
+        unfurl_links: false,
       });
     } catch (error) {
       functions.logger.error("error", { error });
@@ -147,6 +148,7 @@ export const createSlackApp = (
               ts: body.container.message_ts,
               text: newRotation.message,
               blocks: RotationMessage({ rotation: newRotation, userNameDict }),
+              unfurl_links: false,
             });
           } catch (error) {
             functions.logger.error("error", { error });
@@ -165,6 +167,7 @@ export const createSlackApp = (
               ts: body.container.message_ts,
               text: newRotation.message,
               blocks: RotationMessage({ rotation: newRotation, userNameDict }),
+              unfurl_links: false,
             });
           } catch (error) {
             functions.logger.error("error", { error });
@@ -203,6 +206,7 @@ export const createSlackApp = (
         channel: rotation.channel,
         text: rotation.message,
         blocks: RotationMessage({ rotation, userNameDict }),
+        unfurl_links: false,
       });
     } catch (error) {
       functions.logger.error("error", { error });


### PR DESCRIPTION
表示される条件がいまいちわからないが、プレビューがつく場合がある。ただし、

- メッセージ https://example.com
- @user_1 → @user_2 → @user_3 [...]
- プレビュー

のように、リンクとプレビューの位置が離れて表示されるのでいまいち。毎回表示されるのも邪魔だし、無効にしてしまう。

- [chat.postMessage method | Slack](https://api.slack.com/methods/chat.postMessage#arg_unfurl_links)
- [Unfurling links in messages | Slack](https://api.slack.com/reference/messaging/link-unfurling#no_unfurling_please)

