### PR TITLE
rotation から `onDuty` フィールドを削除し、実装をシンプルにする

### DIFF
--- a/functions/src/__tests__/__snapshots__/component.test.tsx.snap
+++ b/functions/src/__tests__/__snapshots__/component.test.tsx.snap
@@ -59,7 +59,7 @@ message line 2",
       "type": "overflow",
     },
     "text": Object {
-      "text": "👑 <@user-b|>→ @userC → @userA",
+      "text": "👑 <@user-a|>→ @userB → @userC",
       "type": "mrkdwn",
       "verbatim": true,
     },
@@ -127,7 +127,7 @@ message line 2",
       "type": "overflow",
     },
     "text": Object {
-      "text": "👑 <@user-b|>→ <@user-c|>→<@user-a|>",
+      "text": "👑 <@user-a|>→ <@user-b|>→<@user-c|>",
       "type": "mrkdwn",
       "verbatim": true,
     },
@@ -1240,7 +1240,7 @@ Array [
       "type": "overflow",
     },
     "text": Object {
-      "text": "&gt; 👑 <@user-c|>→ <@user-a|>→<@user-b|>
+      "text": "&gt; 👑 <@user-b|>→ <@user-c|>→<@user-a|>
 &gt; ",
       "type": "mrkdwn",
       "verbatim": true,
@@ -1303,7 +1303,7 @@ Array [
       "type": "overflow",
     },
     "text": Object {
-      "text": "&gt; 👑 <@user-c|>→ @userA → @userB
+      "text": "&gt; 👑 <@user-b|>→ @userC → @userA
 &gt; ",
       "type": "mrkdwn",
       "verbatim": true,
@@ -1366,7 +1366,7 @@ Array [
       "type": "overflow",
     },
     "text": Object {
-      "text": "&gt; 👑 <@user-c|>→ <@user-a|>→<@user-b|>
+      "text": "&gt; 👑 <@user-b|>→ <@user-c|>→<@user-a|>
 &gt; ",
       "type": "mrkdwn",
       "verbatim": true,

--- a/functions/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/functions/src/__tests__/__snapshots__/index.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`functions cron posts matched rotations and updates onDuty fields of them 1`] = `
+exports[`functions cron posts matched rotations and updates members field of them 1`] = `
 Array [
   Array [
     Object {
@@ -133,7 +133,7 @@ Array [
             "type": "overflow",
           },
           "text": Object {
-            "text": "👑 <@user-p|>→<@user-q|>",
+            "text": "👑 <@user-q|>→<@user-p|>",
             "type": "mrkdwn",
             "verbatim": true,
           },

--- a/functions/src/__tests__/component.test.tsx
+++ b/functions/src/__tests__/component.test.tsx
@@ -5,7 +5,6 @@ import { Rotation } from "../model/rotation";
 const rotationMentionAll = Rotation.fromJSON({
   id: "rotation-id",
   members: ["user-a", "user-b", "user-c"],
-  onDuty: "user-b",
   message: "message line 1\nmessage line 2",
   channel: "channel-id",
   schedule: {
@@ -19,7 +18,6 @@ const rotationMentionAll = Rotation.fromJSON({
 const rotationNotMentionAll = Rotation.fromJSON({
   id: "rotation-id",
   members: ["user-a", "user-b", "user-c"],
-  onDuty: "user-b",
   message: "message line 1\nmessage line 2",
   channel: "channel-id",
   schedule: {

--- a/functions/src/__tests__/index.helper.ts
+++ b/functions/src/__tests__/index.helper.ts
@@ -59,7 +59,6 @@ export const rotations: readonly RotationJSON[] = [
   {
     id: "rotation-1",
     members: ["user-a", "user-b", "user-c"],
-    onDuty: "user-a",
     message: "rotation-1 message",
     channel: "channel-1",
     schedule: {
@@ -72,7 +71,6 @@ export const rotations: readonly RotationJSON[] = [
   {
     id: "rotation-2",
     members: ["user-p", "user-q"],
-    onDuty: "user-q",
     message: "rotation-2 message",
     channel: "channel-2",
     schedule: {
@@ -85,7 +83,6 @@ export const rotations: readonly RotationJSON[] = [
   {
     id: "rotation-3",
     members: ["user-s", "user-t"],
-    onDuty: "user-s",
     message: "rotation-3 message",
     channel: "channel-3",
     schedule: {
@@ -98,7 +95,6 @@ export const rotations: readonly RotationJSON[] = [
   {
     id: "rotation-4",
     members: ["user-x", "user-y", "user-z"],
-    onDuty: "user-y",
     message: "rotation-4 message",
     channel: "channel-4",
     schedule: {

--- a/functions/src/__tests__/index.test.ts
+++ b/functions/src/__tests__/index.test.ts
@@ -164,9 +164,8 @@ describe("functions", () => {
       const submittedRotation = {
         id: "1597200000000",
         channel: "channel-id",
-        members: ["user-a", "user-b", "user-c"],
+        members: ["user-c", "user-a", "user-b"],
         message: "てすてす\n\n*テスト*です",
-        onDuty: "user-c",
         schedule: {
           days: [1, 3, 5],
           hour: 23,
@@ -266,7 +265,7 @@ describe("functions", () => {
           expect(client.chat.postMessage.mock.calls).toMatchSnapshot();
 
           expect(await getAllRotations()).toEqual([
-            { ...rotations[0], onDuty: "user-b" },
+            { ...rotations[0], members: ["user-b", "user-c", "user-a"] },
             rotations[1],
             rotations[2],
             rotations[3],
@@ -303,7 +302,7 @@ describe("functions", () => {
           expect(client.chat.postMessage.mock.calls).toMatchSnapshot();
 
           expect(await getAllRotations()).toEqual([
-            { ...rotations[0], onDuty: "user-c" },
+            { ...rotations[0], members: ["user-c", "user-a", "user-b"] },
             rotations[1],
             rotations[2],
             rotations[3],
@@ -367,14 +366,14 @@ describe("functions", () => {
   describe("cron", () => {
     const wrappedCron = test.wrap(cron);
 
-    it("posts matched rotations and updates onDuty fields of them", async () => {
+    it("posts matched rotations and updates members field of them", async () => {
       await wrappedCron({
         timestamp: "2020-08-08T22:33:44.000Z", // Sun, 09 Aug 2020 07:33:44 JST
       });
       expect(client.chat.postMessage.mock.calls).toMatchSnapshot();
       expect(await getAllRotations()).toEqual([
-        { ...rotations[0], onDuty: "user-b" },
-        { ...rotations[1], onDuty: "user-p" },
+        { ...rotations[0], members: ["user-b", "user-c", "user-a"] },
+        { ...rotations[1], members: ["user-q", "user-p"] },
         rotations[2],
         rotations[3],
       ]);

--- a/functions/src/component.tsx
+++ b/functions/src/component.tsx
@@ -124,8 +124,8 @@ const Order = ({
   readonly userNameDict: Record<string, string> | null;
 }) => (
   <Fragment>
-    👑 <a href={`@${rotation.onDuty}`} />
-    {rotation.getOrderedRestMembers().map((member) => (
+    👑 <a href={`@${rotation.members[0]}`} />
+    {rotation.members.slice(1).map((member) => (
       <Fragment>
         {" → "}
         {/* 念のため、条件に !userNameDict を含めてはいるが、

--- a/functions/src/model/__tests__/rotation.test.ts
+++ b/functions/src/model/__tests__/rotation.test.ts
@@ -5,7 +5,6 @@ describe("Rotation", () => {
   const json = {
     id: "rotation-id",
     members: ["user-a", "user-b", "user-c"],
-    onDuty: "user-b",
     message: "message line 1\nmessage line 2",
     channel: "channel-id",
     schedule: {
@@ -28,7 +27,6 @@ describe("Rotation", () => {
       const rotation = Rotation.fromJSON(json);
       expect(rotation.id).toBe(json.id);
       expect(rotation.members).toEqual(json.members);
-      expect(rotation.onDuty).toBe(json.onDuty);
       expect(rotation.channel).toBe(json.channel);
       expect(rotation.schedule.toJSON()).toEqual(json.schedule);
       expect(rotation.mentionAll).toBe(json.mentionAll);
@@ -39,35 +37,16 @@ describe("Rotation", () => {
       const rotation = Rotation.fromJSON({ ...json, id: undefined });
       expect(rotation.id).toBe("1597200000000");
     });
-
-    it("defaults to the last member for onDuty", () => {
-      const rotation = Rotation.fromJSON({ ...json, onDuty: undefined });
-      expect(rotation.onDuty).toBe("user-c");
-    });
   });
 
   describe("rotate", () => {
-    it("rotates onDuty to the next member", () => {
+    it("rotates the members array", () => {
       const original = Rotation.fromJSON(json);
       const rotated = original.rotate();
-      expect(rotated.onDuty).toBe("user-c");
+      expect(rotated.members).toEqual(["user-b", "user-c", "user-a"]);
 
       expect(rotated).not.toBe(original);
       expect(rotated.id).toBe(original.id);
-      expect(rotated.members).toEqual(original.members);
-      expect(rotated.channel).toBe(original.channel);
-      expect(rotated.schedule.toJSON()).toEqual(original.schedule.toJSON());
-      expect(rotated.mentionAll).toBe(json.mentionAll);
-    });
-
-    it("rotates onDuty to the first member when onDuty was the last", () => {
-      const original = Rotation.fromJSON({ ...json, onDuty: "user-c" });
-      const rotated = original.rotate();
-      expect(rotated.onDuty).toBe("user-a");
-
-      expect(rotated).not.toBe(original);
-      expect(rotated.id).toBe(original.id);
-      expect(rotated.members).toEqual(original.members);
       expect(rotated.channel).toBe(original.channel);
       expect(rotated.schedule.toJSON()).toEqual(original.schedule.toJSON());
       expect(rotated.mentionAll).toBe(json.mentionAll);
@@ -75,37 +54,16 @@ describe("Rotation", () => {
   });
 
   describe("unrotate", () => {
-    it("unrotates onDuty to the previous member", () => {
+    it("unrotates the members array", () => {
       const original = Rotation.fromJSON(json);
       const rotated = original.unrotate();
-      expect(rotated.onDuty).toBe("user-a");
+      expect(rotated.members).toEqual(["user-c", "user-a", "user-b"]);
 
       expect(rotated).not.toBe(original);
       expect(rotated.id).toBe(original.id);
-      expect(rotated.members).toEqual(original.members);
       expect(rotated.channel).toBe(original.channel);
       expect(rotated.schedule.toJSON()).toEqual(original.schedule.toJSON());
       expect(rotated.mentionAll).toBe(json.mentionAll);
-    });
-
-    it("unrotates onDuty to the last member when onDuty was the first", () => {
-      const original = Rotation.fromJSON({ ...json, onDuty: "user-a" });
-      const rotated = original.unrotate();
-      expect(rotated.onDuty).toBe("user-c");
-
-      expect(rotated).not.toBe(original);
-      expect(rotated.id).toBe(original.id);
-      expect(rotated.members).toEqual(original.members);
-      expect(rotated.channel).toBe(original.channel);
-      expect(rotated.schedule.toJSON()).toEqual(original.schedule.toJSON());
-      expect(rotated.mentionAll).toBe(json.mentionAll);
-    });
-  });
-
-  describe("getOrderedRestMembers", () => {
-    it("returns non-onDuty members in the rotation order", () => {
-      const rotation = Rotation.fromJSON(json);
-      expect(rotation.getOrderedRestMembers()).toEqual(["user-c", "user-a"]);
     });
   });
 });

--- a/functions/src/slack.ts
+++ b/functions/src/slack.ts
@@ -90,7 +90,7 @@ export const createSlackApp = (
       mentionAll: JSON.parse(
         view.state.values[ID.MENTION_ALL][ID.MENTION_ALL].selected_option.value
       ),
-    });
+    }).unrotate(); // store には「前回の担当者が先頭」になるように保存するので、一つ戻した状態にする
 
     await rotationStore.set(rotation);
 
@@ -151,7 +151,10 @@ export const createSlackApp = (
             await app.client.views.open({
               token: config.slack.bot_token,
               trigger_id: body.trigger_id,
-              view: RotationModal({ channelId, rotation }),
+              view: RotationModal({
+                channelId,
+                rotation: rotation.rotate(), // 次回の担当者を先頭に表示したいので、rotate でずらしておく
+              }),
             });
           } catch (error) {
             functions.logger.error("error", { error });


### PR DESCRIPTION
今までは

- `members`: 順序固定の配列
- `onDuty`: （前回 post 時の）担当者

としていたが、`members` の配列自体を rotate/unrotate するように変更する。また、`onDuty` フィールドは不要なので削除する。

これによって、#26 で実装した編集時にも、次の担当者が先頭に表示されるようになり、新規作成の場合との一貫性が出る。

既存のデータは要 migrate。