### PR TITLE
master ブランチが更新されたら GitHub Actions から Firebase にデプロイする

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,26 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: functions
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: "10.x"
+      - run: npm ci
+      - name: Deploy to Firebase
+        uses: w9jds/firebase-action@master
+        with:
+          args: deploy
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+          PROJECT_ID: ${{ secrets.PRODUCTION_PROJECT_ID }}


### PR DESCRIPTION
[GitHub Action for Firebase](https://github.com/marketplace/actions/github-action-for-firebase) を使ってみる。

GitHub の設定画面から、以下の secret を設定した。

- `FIREBASE_TOKEN`: デプロイに使うトークン。`$ firebase login:ci` で取得できる
- `PRODUCTION_PROJECT_ID`: デプロイ先の Firebase プロジェクトの ID