### PR TITLE
「担当者だけにメンションする」を選択していても全員にメンションされるバグを修正

### DIFF
--- a/functions/src/services/getUserNameDict.ts
+++ b/functions/src/services/getUserNameDict.ts
@@ -4,13 +4,14 @@ import { Rotation } from "../models/rotation";
 
 /**
  * ローテーションの描画に必要な { [user_id]: user_name } の辞書を返す
- * rotation.mentionAll が false の場合は不要なので、null を返す
+ * （メンション**でない**ユーザー名の表示に必要になる）
+ * rotation.mentionAll が true の場合は不要なので、null を返す
  */
 export const getUserNameDict = async (
   rotation: Rotation,
   client: WebClient
 ): Promise<Record<string, string> | null> => {
-  if (!rotation.mentionAll) return null;
+  if (rotation.mentionAll) return null;
 
   try {
     const json = await client.users.list();


### PR DESCRIPTION
@tsub さんより :thx:

> Slack の仕様変更なのか、Rota の実装変更なのか分かりませんが、Rota で「担当者だけにメンションする」に設定していても、担当者以外にメンションされてました。
先週金曜日の時点では意図通りの挙動になってました。

https://github.com/mashabow/slack-rota/pull/44/commits/802cf628b63fe210e52546cfa478c5cf27a6e2ae のリファクタリングで条件を逆にしていた 🙇