### PR TITLE
非メンション表示において、別ワークスペースのメンバーが `@undefiled` と表示されてしまう問題を修正

### DIFF
--- a/functions/src/services/getUserNameDict.ts
+++ b/functions/src/services/getUserNameDict.ts
@@ -14,14 +14,16 @@ export const getUserNameDict = async (
   if (rotation.mentionAll) return null;
 
   try {
-    const json = await client.users.list();
-    // 型定義上は optional だが、正常系では必ず存在するはず
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    return json.members!.reduce<Record<string, string>>(
-      (acc, { id, profile }) => ({
+    const responses = await Promise.all(
+      rotation.members.map((member) => client.users.info({ user: member }))
+    );
+    return responses.reduce<Record<string, string>>(
+      (acc, { user }) => ({
         ...acc,
+        // 型定義上は optional だが、正常系では必ず存在するはず
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        [id!]: profile?.display_name || profile?.real_name || "",
+        [user!.id!]:
+          user?.profile?.display_name || user?.profile?.real_name || "???",
       }),
       {}
     );


### PR DESCRIPTION
Fix #51

> [`users.list`](https://api.slack.com/methods/users.list) だと、Rota が動いているワークスペースのユーザーしか取得できない。Slack コネクトで参加している別ワークスペースのユーザー（[*external members*](https://api.slack.com/apis/channels-between-orgs#technical-considerations-supporting-slack-connect__users-may-seem-strange)）は含まれない。
> 
> user ID を指定して [`users.info`](https://api.slack.com/methods/users.info) を使えば、ワークスペース関係なくそのユーザーの情報を取得できる。

`users.list` ではなく、メンバーの数だけ `users.info` を叩いて取得する。

`users.info` で取得したユーザー名をキャッシュ（Firestore に保存）しておいた方が効率的かもしれないが、複雑になるので、今回はそこまでは対応しない。

ちなみに、`users.info` の rate limit は Tier 4（100+ per minute）なので、そこそこ余裕はある。Slack の rate limit はアプリごと・ワークスペースごとにカウントされる。